### PR TITLE
Implement IPv6

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,7 +53,7 @@ function IRCServer(port) {
     this.irc = net.createServer(function (c) {
         self.newClient(c);
     });
-    this.irc.listen(port, function () {
+    this.irc.listen(port, "::", function () {
         console.log('Listening on port', port);
     });
 }


### PR DESCRIPTION
Adds IPv6 listening when nodejs net module opens a port.

This isn't well tested but so far I have not noticed an issue.
