### PR TITLE
Fixed JOIN sequence

### DIFF
--- a/server.js
+++ b/server.js
@@ -322,8 +322,8 @@ Client.prototype.handleNICK = function (prefix, args) {
             pass: false
         });
     } else if (!this.inChannel) {
-        this.handleJOIN(prefix,  ['#berrytube']);
         this.socket.write(':' + args[0] + ' NICK anonymous\r\n');
+        this.handleJOIN(prefix,  ['#berrytube']);
         this.inChannel = true;
     }
 };


### PR DESCRIPTION
When JOINing a channel, the servers should reply with JOIN,
RPL_TOPIC and RPL_NAMREPLY  to show the client that the join was
successful, tell the client what the current topic and who is
currently in the channel.

If RPL_NAMREPLY is omitted, the user list may stay empty in
some clients
